### PR TITLE
Fixed absolute path issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get install -qyy texlive-full \
 # Clean up APT when done.
 RUN apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-VOLUME inputData/
+VOLUME /inputData/
 WORKDIR /inputData/
 ENTRYPOINT ["latexmk", "-shell-escape"]


### PR DESCRIPTION
When I try to run the docker image on Ubuntu, it gives me the following error message:

```console
$ ./compileTex.sh 
docker: Error response from daemon: OCI runtime create failed: invalid mount {Destination:inputData Type:bind Source:/var/lib/docker/volumes/029846acc5934ccb1fe8ca784d4c8db249b8f2163c1f5e457a41f81467341ae2/_data Options:[rbind]}: mount destination inputData not absolute: unknown.
```

Changing the path from `inputData` to `/inputData` in the `Dockerfile` solves the issue for me.
